### PR TITLE
Changes from previous PR

### DIFF
--- a/src/main/java/org/victorrobotics/frc/dtlib/actuator/motor/DTMotor.java
+++ b/src/main/java/org/victorrobotics/frc/dtlib/actuator/motor/DTMotor.java
@@ -20,8 +20,8 @@ public interface DTMotor<MOTORTYPE> extends DTSendable {
                 this::setPercentOutput);
         builder.addDoubleProperty("Position",
                 limitRate(this::getEncoderPosition, UPDATE_RATE_FAST_HZ), this::setPosition);
-        builder.addDoubleProperty("Velocity",
-                limitRate(this::getEncoderVelocity, UPDATE_RATE_FAST_HZ), this::setVelocity);
+        builder.addDoubleProperty("Velocity", limitRate(this::getVelocityRPM, UPDATE_RATE_FAST_HZ),
+                this::setVelocity);
 
         builder.addBooleanProperty("Brake mode",
                 limitRate(this::isBrakeEnabled, UPDATE_RATE_SLOW_HZ), this::configBrakeMode);
@@ -118,7 +118,7 @@ public interface DTMotor<MOTORTYPE> extends DTSendable {
 
     double getEncoderPosition();
 
-    double getEncoderVelocity();
+    double getVelocityRPM();
 
     DTMotorFaults getFaults();
 

--- a/src/main/java/org/victorrobotics/frc/dtlib/actuator/motor/DTMotor.java
+++ b/src/main/java/org/victorrobotics/frc/dtlib/actuator/motor/DTMotor.java
@@ -1,14 +1,10 @@
 package org.victorrobotics.frc.dtlib.actuator.motor;
 
-import org.victorrobotics.frc.dtlib.function.supplier.DTLimitedBooleanSupplier;
-import org.victorrobotics.frc.dtlib.function.supplier.DTLimitedDoubleSupplier;
-import org.victorrobotics.frc.dtlib.function.supplier.DTLimitedLongSupplier;
-import org.victorrobotics.frc.dtlib.function.supplier.DTLimitedSupplier;
 import org.victorrobotics.frc.dtlib.network.DTSendable;
 
 import edu.wpi.first.util.sendable.SendableBuilder;
 
-public interface DTMotor<MOTORTYPE, CURRENTLIMITTYPE> extends DTSendable, AutoCloseable {
+public interface DTMotor<MOTORTYPE> extends DTSendable {
     @Override
     void close();
 
@@ -17,52 +13,47 @@ public interface DTMotor<MOTORTYPE, CURRENTLIMITTYPE> extends DTSendable, AutoCl
         builder.setActuator(true);
         builder.setSafeState(this::neutralOutput);
 
-        builder.addIntegerProperty("CAN ID",
-                new DTLimitedLongSupplier(this::getCanID, UPDATE_RATE_SLOW_HZ), null);
+        builder.addIntegerProperty("CAN ID", limitRate(this::getCanID, UPDATE_RATE_SLOW_HZ), null);
 
-        builder.addDoubleProperty("Output", this::getMotorOutputPercent, this::setPercentOutput);
-        builder.addDoubleProperty("Position", this::getEncoderPosition, this::setPosition);
-        builder.addDoubleProperty("Velocity", this::getEncoderVelocity, this::setVelocity);
+        builder.addDoubleProperty("Output",
+                limitRate(this::getMotorOutputPercent, UPDATE_RATE_FAST_HZ),
+                this::setPercentOutput);
+        builder.addDoubleProperty("Position",
+                limitRate(this::getEncoderPosition, UPDATE_RATE_FAST_HZ), this::setPosition);
+        builder.addDoubleProperty("Velocity",
+                limitRate(this::getEncoderVelocity, UPDATE_RATE_FAST_HZ), this::setVelocity);
 
         builder.addBooleanProperty("Brake mode",
-                new DTLimitedBooleanSupplier(this::isBrakeEnabled, UPDATE_RATE_SLOW_HZ),
-                this::configBrakeMode);
+                limitRate(this::isBrakeEnabled, UPDATE_RATE_SLOW_HZ), this::configBrakeMode);
         builder.addBooleanProperty("Inverted",
-                new DTLimitedBooleanSupplier(this::isOutputInverted, UPDATE_RATE_SLOW_HZ),
-                this::configOutputInverted);
+                limitRate(this::isOutputInverted, UPDATE_RATE_SLOW_HZ), this::configOutputInverted);
 
-        builder.addDoubleProperty("kP",
-                new DTLimitedDoubleSupplier(this::getPIDproportional, UPDATE_RATE_SLOW_HZ),
+        builder.addDoubleProperty("kP", limitRate(this::getPIDproportional, UPDATE_RATE_SLOW_HZ),
                 this::configPIDproportional);
-        builder.addDoubleProperty("kI",
-                new DTLimitedDoubleSupplier(this::getPIDintegral, UPDATE_RATE_SLOW_HZ),
+        builder.addDoubleProperty("kI", limitRate(this::getPIDintegral, UPDATE_RATE_SLOW_HZ),
                 this::configPIDintegral);
-        builder.addDoubleProperty("kD",
-                new DTLimitedDoubleSupplier(this::getPIDderivative, UPDATE_RATE_SLOW_HZ),
+        builder.addDoubleProperty("kD", limitRate(this::getPIDderivative, UPDATE_RATE_SLOW_HZ),
                 this::configPIDderivative);
-        builder.addDoubleProperty("kF",
-                new DTLimitedDoubleSupplier(this::getPIDfeedforward, UPDATE_RATE_SLOW_HZ),
+        builder.addDoubleProperty("kF", limitRate(this::getPIDfeedforward, UPDATE_RATE_SLOW_HZ),
                 this::configPIDfeedforward);
-        builder.addDoubleProperty("kIZ",
-                new DTLimitedDoubleSupplier(this::getPIDintegralZone, UPDATE_RATE_SLOW_HZ),
+        builder.addDoubleProperty("kIZ", limitRate(this::getPIDintegralZone, UPDATE_RATE_SLOW_HZ),
                 this::configPIDintegralZone);
 
-        builder.addDoubleProperty("Voltage",
-                new DTLimitedDoubleSupplier(this::getInputVoltage, UPDATE_RATE_STD_HZ), null);
-        builder.addDoubleProperty("Temperature",
-                new DTLimitedDoubleSupplier(this::getTemperature, UPDATE_RATE_SLOW_HZ), null);
-        builder.addBooleanProperty("Fault",
-                new DTLimitedBooleanSupplier(() -> getFaults().hasAnyFault(), UPDATE_RATE_STD_HZ),
+        builder.addDoubleProperty("Voltage", limitRate(this::getInputVoltage, UPDATE_RATE_STD_HZ),
                 null);
+        builder.addDoubleProperty("Temperature",
+                limitRate(this::getTemperature, UPDATE_RATE_SLOW_HZ), null);
+        builder.addBooleanProperty("Fault",
+                limitRate(() -> getFaults().hasAnyFault(), UPDATE_RATE_STD_HZ), null);
         builder.addStringProperty("Firmware",
-                new DTLimitedSupplier<>(this::getFirmwareVersion, UPDATE_RATE_SLOW_HZ), null);
+                limitRate(this::getFirmwareVersion, UPDATE_RATE_SLOW_HZ), null);
 
         customizeSendable(builder);
     }
 
     default void customizeSendable(SendableBuilder builder) {}
 
-    MOTORTYPE internal();
+    MOTORTYPE getMotorImpl();
 
     int getCanID();
 
@@ -93,7 +84,7 @@ public interface DTMotor<MOTORTYPE, CURRENTLIMITTYPE> extends DTSendable, AutoCl
         configPIDintegralZone(integralZone);
     }
 
-    void configCurrentLimit(CURRENTLIMITTYPE limit);
+    void configCurrentLimit(int maxSupplyCurrent);
 
     boolean isOutputInverted();
 
@@ -132,4 +123,8 @@ public interface DTMotor<MOTORTYPE, CURRENTLIMITTYPE> extends DTSendable, AutoCl
     DTMotorFaults getFaults();
 
     String getFirmwareVersion();
+
+    double getMaxVelocity();
+
+    double getStallTorque();
 }

--- a/src/main/java/org/victorrobotics/frc/dtlib/actuator/motor/DTMotorFaults.java
+++ b/src/main/java/org/victorrobotics/frc/dtlib/actuator/motor/DTMotorFaults.java
@@ -1,8 +1,6 @@
 package org.victorrobotics.frc.dtlib.actuator.motor;
 
-public interface DTMotorFaults<FAULT_TYPE> {
-    FAULT_TYPE getFaultsImpl();
-
+public interface DTMotorFaults {
     boolean hasAnyFault();
 
     boolean lowVoltage();

--- a/src/main/java/org/victorrobotics/frc/dtlib/actuator/motor/DTMotorFaults.java
+++ b/src/main/java/org/victorrobotics/frc/dtlib/actuator/motor/DTMotorFaults.java
@@ -1,7 +1,7 @@
 package org.victorrobotics.frc.dtlib.actuator.motor;
 
 public interface DTMotorFaults<FAULT_TYPE> {
-    FAULT_TYPE internal();
+    FAULT_TYPE getFaultsImpl();
 
     boolean hasAnyFault();
 

--- a/src/main/java/org/victorrobotics/frc/dtlib/actuator/motor/ctre/DTTalonFX.java
+++ b/src/main/java/org/victorrobotics/frc/dtlib/actuator/motor/ctre/DTTalonFX.java
@@ -4,6 +4,7 @@ import org.victorrobotics.frc.dtlib.actuator.motor.DTMotor;
 import org.victorrobotics.frc.dtlib.actuator.motor.DTMotorFaults;
 
 import edu.wpi.first.util.sendable.SendableBuilder;
+import edu.wpi.first.util.sendable.SendableRegistry;
 
 import com.ctre.phoenix.motorcontrol.Faults;
 import com.ctre.phoenix.motorcontrol.NeutralMode;
@@ -12,9 +13,11 @@ import com.ctre.phoenix.motorcontrol.TalonFXControlMode;
 import com.ctre.phoenix.motorcontrol.can.TalonFXConfiguration;
 import com.ctre.phoenix.motorcontrol.can.WPI_TalonFX;
 
-public class DTTalonFX implements DTMotor<WPI_TalonFX, SupplyCurrentLimitConfiguration> {
+public class DTTalonFX implements DTMotor<WPI_TalonFX> {
     private static final double TICKS_PER_REV      = 2048;
     private static final double SECONDS_PER_MINUTE = 60;
+    private static final double MAX_VELOCITY_RPM   = 6380;
+    private static final double STALL_TORQUE       = 4.69;
 
     private final WPI_TalonFX internal;
     private final int         deviceID;
@@ -35,11 +38,12 @@ public class DTTalonFX implements DTMotor<WPI_TalonFX, SupplyCurrentLimitConfigu
 
     public DTTalonFX(int canID, String canBus) {
         internal = new WPI_TalonFX(canID, canBus);
+        SendableRegistry.remove(internal);
         deviceID = canID;
     }
 
     @Override
-    public WPI_TalonFX internal() {
+    public WPI_TalonFX getMotorImpl() {
         return internal;
     }
 
@@ -101,8 +105,13 @@ public class DTTalonFX implements DTMotor<WPI_TalonFX, SupplyCurrentLimitConfigu
     }
 
     @Override
-    public void configCurrentLimit(SupplyCurrentLimitConfiguration maxCurrent) {
-        internal.configSupplyCurrentLimit(maxCurrent);
+    public void configCurrentLimit(int maxSupplyCurrent) {
+        internal.configSupplyCurrentLimit(
+                new SupplyCurrentLimitConfiguration(true, maxSupplyCurrent, maxSupplyCurrent, 0));
+    }
+
+    public void configCurrentLimit(SupplyCurrentLimitConfiguration currentConfig) {
+        internal.configSupplyCurrentLimit(currentConfig);
     }
 
     public void configAllSettings(TalonFXConfiguration config) {
@@ -197,7 +206,7 @@ public class DTTalonFX implements DTMotor<WPI_TalonFX, SupplyCurrentLimitConfigu
 
     @Override
     public double getEncoderVelocity() {
-        return internal.getSelectedSensorVelocity() / TICKS_PER_REV * 10;
+        return internal.getSelectedSensorVelocity() / TICKS_PER_REV * 10 * SECONDS_PER_MINUTE;
     }
 
     public DTTalonFXFaults getFaults() {
@@ -245,7 +254,7 @@ public class DTTalonFX implements DTMotor<WPI_TalonFX, SupplyCurrentLimitConfigu
         }
 
         @Override
-        public Faults internal() {
+        public Faults getFaultsImpl() {
             return internal;
         }
 
@@ -293,5 +302,15 @@ public class DTTalonFX implements DTMotor<WPI_TalonFX, SupplyCurrentLimitConfigu
         public boolean hardwareFailure() {
             return internal.HardwareFailure;
         }
+    }
+
+    @Override
+    public double getMaxVelocity() {
+        return MAX_VELOCITY_RPM;
+    }
+
+    @Override
+    public double getStallTorque() {
+        return STALL_TORQUE;
     }
 }

--- a/src/main/java/org/victorrobotics/frc/dtlib/actuator/motor/ctre/DTTalonFX.java
+++ b/src/main/java/org/victorrobotics/frc/dtlib/actuator/motor/ctre/DTTalonFX.java
@@ -110,8 +110,10 @@ public class DTTalonFX implements DTMotor<WPI_TalonFX> {
                 new SupplyCurrentLimitConfiguration(true, maxSupplyCurrent, maxSupplyCurrent, 0));
     }
 
-    public void configCurrentLimit(SupplyCurrentLimitConfiguration currentConfig) {
-        internal.configSupplyCurrentLimit(currentConfig);
+    public void configCurrentLimit(double baseCurrentLimit, double peakCurrentLimit,
+            double peakDuration) {
+        internal.configSupplyCurrentLimit(new SupplyCurrentLimitConfiguration(true,
+                baseCurrentLimit, peakCurrentLimit, peakDuration));
     }
 
     public void configAllSettings(TalonFXConfiguration config) {
@@ -205,7 +207,7 @@ public class DTTalonFX implements DTMotor<WPI_TalonFX> {
     }
 
     @Override
-    public double getEncoderVelocity() {
+    public double getVelocityRPM() {
         return internal.getSelectedSensorVelocity() / TICKS_PER_REV * 10 * SECONDS_PER_MINUTE;
     }
 
@@ -244,18 +246,13 @@ public class DTTalonFX implements DTMotor<WPI_TalonFX> {
         return internal.getBusVoltage();
     }
 
-    public static class DTTalonFXFaults implements DTMotorFaults<Faults> {
+    public static class DTTalonFXFaults implements DTMotorFaults {
         private static final int OTHER_FAULTS_MASK = 0b00111111_10000000;
 
         private final Faults internal;
 
         DTTalonFXFaults(Faults internal) {
             this.internal = internal;
-        }
-
-        @Override
-        public Faults getFaultsImpl() {
-            return internal;
         }
 
         @Override

--- a/src/main/java/org/victorrobotics/frc/dtlib/actuator/motor/revrobotics/DTNeo.java
+++ b/src/main/java/org/victorrobotics/frc/dtlib/actuator/motor/revrobotics/DTNeo.java
@@ -171,7 +171,7 @@ public class DTNeo implements DTMotor<CANSparkMax> {
     }
 
     @Override
-    public double getEncoderVelocity() {
+    public double getVelocityRPM() {
         return encoder.getVelocity();
     }
 
@@ -185,18 +185,13 @@ public class DTNeo implements DTMotor<CANSparkMax> {
         return internal.getFirmwareString();
     }
 
-    public static class DTNeoFaults implements DTMotorFaults<Short> {
+    public static class DTNeoFaults implements DTMotorFaults {
         private static final short OTHER_FAULTS_MASK = 0b00001101_11110110;
 
         private final short internal;
 
         DTNeoFaults(short internal) {
             this.internal = internal;
-        }
-
-        @Override
-        public Short getFaultsImpl() {
-            return Short.valueOf(internal);
         }
 
         @Override

--- a/src/main/java/org/victorrobotics/frc/dtlib/network/DTSendable.java
+++ b/src/main/java/org/victorrobotics/frc/dtlib/network/DTSendable.java
@@ -1,13 +1,48 @@
 package org.victorrobotics.frc.dtlib.network;
 
+import org.victorrobotics.frc.dtlib.function.supplier.DTLimitedBooleanSupplier;
+import org.victorrobotics.frc.dtlib.function.supplier.DTLimitedDoubleSupplier;
+import org.victorrobotics.frc.dtlib.function.supplier.DTLimitedFloatSupplier;
+import org.victorrobotics.frc.dtlib.function.supplier.DTLimitedLongSupplier;
+import org.victorrobotics.frc.dtlib.function.supplier.DTLimitedSupplier;
+
+import java.util.function.BooleanSupplier;
+import java.util.function.DoubleSupplier;
+import java.util.function.LongSupplier;
+import java.util.function.Supplier;
+
+import edu.wpi.first.util.function.FloatSupplier;
 import edu.wpi.first.util.sendable.Sendable;
 import edu.wpi.first.util.sendable.SendableBuilder;
 
-public interface DTSendable extends Sendable {
+public interface DTSendable extends Sendable, AutoCloseable {
     double UPDATE_RATE_FAST_HZ = 25;
     double UPDATE_RATE_STD_HZ  = 10;
     double UPDATE_RATE_SLOW_HZ = 2;
 
     @Override
     void initSendable(SendableBuilder builder);
+
+    @Override
+    void close() throws Exception;
+
+    default DTLimitedDoubleSupplier limitRate(DoubleSupplier supplier, double rateHz) {
+        return new DTLimitedDoubleSupplier(supplier, rateHz);
+    }
+
+    default DTLimitedFloatSupplier limitRate(FloatSupplier supplier, double rateHz) {
+        return new DTLimitedFloatSupplier(supplier, rateHz);
+    }
+
+    default DTLimitedBooleanSupplier limitRate(BooleanSupplier supplier, double rateHz) {
+        return new DTLimitedBooleanSupplier(supplier, rateHz);
+    }
+
+    default DTLimitedLongSupplier limitRate(LongSupplier supplier, double rateHz) {
+        return new DTLimitedLongSupplier(supplier, rateHz);
+    }
+
+    default <T> DTLimitedSupplier<T> limitRate(Supplier<T> supplier, double rateHz) {
+        return new DTLimitedSupplier<>(supplier, rateHz);
+    }
 }


### PR DESCRIPTION
- `DTSendable` forces subclasses to  implement `AutoCloseable`
- `DTSendable` convenience methods to limit NetworkTables entry refresh rate
- Remove `CURRENTLIMITTYPE` generic parameter from `DTMotor` and change to a single `int` parameter
- Add type-specific `configCurrentLimit()` methods to `DTTalonFX` and `DTNeo`
- Rename `DTMotor::internal()` to 'getMotorImpl()`
- Rename 'DTMotorFaults::internal()` to 'getFaultsImpl()`
- Add `DTMotor::getMaxVelocity()` and `getStallTorque()` methods to interface
- Bugfixes