### PR TITLE
Cleanup DTLog, implement log levels

### DIFF
--- a/src/main/java/org/victorrobotics/dtlib/DTLibInfo.java
+++ b/src/main/java/org/victorrobotics/dtlib/DTLibInfo.java
@@ -1,11 +1,13 @@
 package org.victorrobotics.dtlib;
 
-public class DTLibInfo {
-  public static class Version {
-    public static final int    YEAR    = 0;
-    public static final int    MAJOR   = 1;
-    public static final int    MINOR   = 0;
-    public static final String VERSION = YEAR + "." + MAJOR + "." + MINOR;
+public final class DTLibInfo {
+  public static final class Version {
+    public static final int    YEAR   = 0;
+    public static final int    MAJOR  = 1;
+    public static final int    MINOR  = 0;
+    public static final String SUFFIX = null;
+    public static final String STRING =
+        YEAR + "." + MAJOR + "." + MINOR + (SUFFIX == null ? "" : ("-" + SUFFIX));
 
     private Version() {}
   }

--- a/src/main/java/org/victorrobotics/dtlib/DTRobot.java
+++ b/src/main/java/org/victorrobotics/dtlib/DTRobot.java
@@ -6,7 +6,6 @@ import org.victorrobotics.dtlib.log.DTLogRootNode;
 import org.victorrobotics.dtlib.log.DTLogWriter;
 import org.victorrobotics.dtlib.log.DTWatchdog;
 
-import java.io.IOException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 
@@ -21,6 +20,7 @@ import edu.wpi.first.wpilibj.Compressor;
 import edu.wpi.first.wpilibj.DSControlWord;
 import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.PneumaticsModuleType;
+import edu.wpi.first.wpilibj.RobotController;
 import edu.wpi.first.wpilibj.RuntimeType;
 
 public abstract class DTRobot {
@@ -126,9 +126,6 @@ public abstract class DTRobot {
   private void runModeChange() {
     if (currentMode == previousMode) return;
 
-    DTLogWriter.getInstance()
-               .writeShort(currentMode.identifier);
-
     if (currentMode == Mode.AUTO) {
       DTWatchdog.startEpoch();
       autoCommand = getAutoCommand();
@@ -156,10 +153,8 @@ public abstract class DTRobot {
                  .writeShort(currentMode.identifier);
     }
     robot.logTreeRoot.log();
-    try {
-      DTLogWriter.getInstance()
-                 .flush();
-    } catch (IOException e) {}
+    DTLogWriter.getInstance()
+               .tryFlush();
     DTWatchdog.addEpoch("DTLog");
   }
 
@@ -294,6 +289,10 @@ public abstract class DTRobot {
     return alliance;
   }
 
+  public static int getTeamNumber() {
+    return RobotController.getTeamNumber();
+  }
+
   public static boolean isSimulation() {
     return IS_SIMULATION;
   }
@@ -307,7 +306,7 @@ public abstract class DTRobot {
   }
 
   public static long currentTimeMicros() {
-    return HALUtil.getFPGATime();
+    return RobotController.getFPGATime();
   }
 
   public static double currentTime() {

--- a/src/main/java/org/victorrobotics/dtlib/DTRobot.java
+++ b/src/main/java/org/victorrobotics/dtlib/DTRobot.java
@@ -2,6 +2,7 @@ package org.victorrobotics.dtlib;
 
 import org.victorrobotics.dtlib.command.DTCommand;
 import org.victorrobotics.dtlib.command.DTCommandScheduler;
+import org.victorrobotics.dtlib.log.DTLog;
 import org.victorrobotics.dtlib.log.DTLogRootNode;
 import org.victorrobotics.dtlib.log.DTLogWriter;
 import org.victorrobotics.dtlib.log.DTWatchdog;
@@ -74,6 +75,7 @@ public abstract class DTRobot {
 
   private static AllianceStation alliance;
 
+  private final DTLog.Level logLevel;
   private final DTLogRootNode logTreeRoot;
 
   private Compressor compressor;
@@ -81,7 +83,12 @@ public abstract class DTRobot {
   private DTCommand autoCommand;
 
   protected DTRobot() {
-    logTreeRoot = new DTLogRootNode(this, getName());
+    this(DTLog.Level.INFO);
+  }
+
+  protected DTRobot(DTLog.Level logLevel) {
+    this.logLevel = logLevel;
+    logTreeRoot = new DTLogRootNode(this, logLevel);
   }
 
   /**
@@ -175,7 +182,6 @@ public abstract class DTRobot {
 
     startNTServer();
     refreshDriverStation();
-    DTLogWriter.init();
 
     DTRobot robot;
     try {
@@ -189,6 +195,8 @@ public abstract class DTRobot {
       t.printStackTrace();
       return;
     }
+
+    DTLogWriter.init(robot.logLevel);
 
     System.out.println("[DTLib] " + robot.getName() + " initializing...");
     robot.init();

--- a/src/main/java/org/victorrobotics/dtlib/DTRobot.java
+++ b/src/main/java/org/victorrobotics/dtlib/DTRobot.java
@@ -75,7 +75,7 @@ public abstract class DTRobot {
 
   private static AllianceStation alliance;
 
-  private final DTLog.Level logLevel;
+  private final DTLog.Level   logLevel;
   private final DTLogRootNode logTreeRoot;
 
   private Compressor compressor;
@@ -206,9 +206,9 @@ public abstract class DTRobot {
         robot.simulationInit();
       }
       robot.bindCommands();
-    } catch (RuntimeException e) {
-      DTLogWriter.error(e.getMessage());
-      throw e;
+    } catch (Throwable t) {
+      DTLogWriter.logException(t, DTLog.Level.ERROR);
+      return;
     }
 
     DriverStationJNI.observeUserProgramStarting();
@@ -268,7 +268,9 @@ public abstract class DTRobot {
       }
       try {
         Thread.sleep(10);
-      } catch (InterruptedException e) {}
+      } catch (InterruptedException e) {
+        DTLogWriter.logException(e, DTLog.Level.INFO);
+      }
     }
   }
 

--- a/src/main/java/org/victorrobotics/dtlib/DTRobot.java
+++ b/src/main/java/org/victorrobotics/dtlib/DTRobot.java
@@ -126,7 +126,11 @@ public abstract class DTRobot {
    */
   protected abstract DTCommand getSelfTestCommand();
 
-  public String getName() {
+  /**
+   * @return the name of the robot
+   */
+  @Override
+  public String toString() {
     return getClass().getSimpleName();
   }
 
@@ -197,7 +201,7 @@ public abstract class DTRobot {
     }
 
     DTLogWriter.init(robot.logLevel);
-    DTLogWriter.info(robot.getName() + " initializing...");
+    DTLogWriter.info(robot + " initializing...");
 
     waitForNTServer();
     try {
@@ -212,7 +216,7 @@ public abstract class DTRobot {
     }
 
     DriverStationJNI.observeUserProgramStarting();
-    DTLogWriter.info(robot.getName() + " ready");
+    DTLogWriter.info(robot + " ready");
 
     int notifierHandle = NotifierJNI.initializeNotifier();
     NotifierJNI.setNotifierName(notifierHandle, "DTRobot");
@@ -237,7 +241,7 @@ public abstract class DTRobot {
       // Execute code for this cycle
       DTWatchdog.startEpoch();
       robot.periodic();
-      DTWatchdog.addEpoch(robot.getName() + ".periodic()");
+      DTWatchdog.addEpoch(robot + ".periodic()");
 
       DTCommandScheduler.run();
       log(robot);

--- a/src/main/java/org/victorrobotics/dtlib/DTRobot.java
+++ b/src/main/java/org/victorrobotics/dtlib/DTRobot.java
@@ -162,7 +162,7 @@ public abstract class DTRobot {
     robot.logTreeRoot.log();
     DTLogWriter.getInstance()
                .tryFlush();
-    DTWatchdog.addEpoch("DTLog");
+    DTWatchdog.addEpoch("log()");
   }
 
   protected final void configCompressor(int module, PneumaticsModuleType type) {
@@ -191,7 +191,7 @@ public abstract class DTRobot {
       if (cause != null) {
         t = cause;
       }
-      System.err.println("[DTLib] Unhandled exception thrown while instantiating robot:");
+      System.err.println("Unhandled exception thrown while instantiating robot:");
       t.printStackTrace();
       return;
     }
@@ -237,7 +237,7 @@ public abstract class DTRobot {
       // Execute code for this cycle
       DTWatchdog.startEpoch();
       robot.periodic();
-      DTWatchdog.addEpoch("periodic()");
+      DTWatchdog.addEpoch(robot.getName() + ".periodic()");
 
       DTCommandScheduler.run();
       log(robot);

--- a/src/main/java/org/victorrobotics/dtlib/command/DTCommandScheduler.java
+++ b/src/main/java/org/victorrobotics/dtlib/command/DTCommandScheduler.java
@@ -2,6 +2,7 @@ package org.victorrobotics.dtlib.command;
 
 import org.victorrobotics.dtlib.DTRobot;
 import org.victorrobotics.dtlib.exception.DTIllegalArgumentException;
+import org.victorrobotics.dtlib.log.DTLogWriter;
 import org.victorrobotics.dtlib.log.DTWatchdog;
 import org.victorrobotics.dtlib.subsystem.DTSubsystem;
 
@@ -16,8 +17,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.WeakHashMap;
-
-import edu.wpi.first.wpilibj.DriverStation;
 
 /**
  * The scheduler responsible for managing DTCommands and DTSubsystems
@@ -184,10 +183,10 @@ public final class DTCommandScheduler {
    */
   public static boolean schedule(DTCommand command) {
     if (command == null) {
-      warn("Tried to schedule a null command");
+      DTLogWriter.warn("Tried to schedule a null command");
       return false;
     } else if (COMPOSED_COMMANDS.contains(command)) {
-      warn("Tried to schedule a composed command");
+      DTLogWriter.warn("Tried to schedule a composed command");
       return false;
     }
 
@@ -257,7 +256,7 @@ public final class DTCommandScheduler {
    */
   public static void cancel(DTCommand command) {
     if (command == null) {
-      warn("Tried to cancel a null command");
+      DTLogWriter.warn("Tried to cancel a null command");
       return;
     } else if (!isScheduled(command)) return;
 
@@ -311,7 +310,7 @@ public final class DTCommandScheduler {
    */
   public static void registerSubsystem(DTSubsystem subsystem) {
     if (subsystem == null) {
-      warn("Tried to register a null subsystem");
+      DTLogWriter.warn("Tried to register a null subsystem");
       return;
     }
 
@@ -402,11 +401,7 @@ public final class DTCommandScheduler {
   }
 
   private static void handleCommandException(DTCommand command, RuntimeException e) {
-    warn(command.getName() + " threw an exception: " + e);
-  }
-
-  private static void warn(String msg) {
-    DriverStation.reportWarning(msg, false);
+    DTLogWriter.warn(command.getName() + " threw an exception: " + e);
   }
 
   /**

--- a/src/main/java/org/victorrobotics/dtlib/command/DTPrintCommand.java
+++ b/src/main/java/org/victorrobotics/dtlib/command/DTPrintCommand.java
@@ -1,5 +1,7 @@
 package org.victorrobotics.dtlib.command;
 
+import org.victorrobotics.dtlib.log.DTLogWriter;
+
 /**
  * A command that prints text to the console when run, finishing immediately.
  * Useful for debugging command logic.
@@ -12,7 +14,11 @@ public class DTPrintCommand extends DTInstantCommand {
    *        the text to be printed
    */
   public DTPrintCommand(String message) {
-    super(() -> System.out.println(message));
+    super(() -> {
+      if (!DTLogWriter.info(message)) {
+        System.out.println(message);
+      }
+    });
   }
 
   @Override

--- a/src/main/java/org/victorrobotics/dtlib/command/DTRecoveryCommand.java
+++ b/src/main/java/org/victorrobotics/dtlib/command/DTRecoveryCommand.java
@@ -1,5 +1,8 @@
 package org.victorrobotics.dtlib.command;
 
+import org.victorrobotics.dtlib.log.DTLog;
+import org.victorrobotics.dtlib.log.DTLogWriter;
+
 /**
  * A command that runs another command, but catches runtime exceptions instead
  * of propogating them back to the scheduler. If an exception is thrown, the
@@ -29,6 +32,7 @@ public class DTRecoveryCommand extends DTTargetCommand {
     try {
       target.initialize();
     } catch (RuntimeException e) {
+      DTLogWriter.logException(e, DTLog.Level.DEBUG);
       threwException = true;
     }
   }
@@ -42,6 +46,7 @@ public class DTRecoveryCommand extends DTTargetCommand {
     try {
       target.execute();
     } catch (RuntimeException e) {
+      DTLogWriter.logException(e, DTLog.Level.DEBUG);
       threwException = true;
     }
   }
@@ -51,13 +56,16 @@ public class DTRecoveryCommand extends DTTargetCommand {
     if (threwException) {
       try {
         target.interrupt();
-      } catch (RuntimeException e) {}
+      } catch (RuntimeException e) {
+        DTLogWriter.logException(e, DTLog.Level.DEBUG);
+      }
       return;
     }
 
     try {
       target.end();
     } catch (RuntimeException e) {
+      DTLogWriter.logException(e, DTLog.Level.DEBUG);
       threwException = true;
     }
   }
@@ -67,6 +75,7 @@ public class DTRecoveryCommand extends DTTargetCommand {
     try {
       target.interrupt();
     } catch (RuntimeException e) {
+      DTLogWriter.logException(e, DTLog.Level.DEBUG);
       threwException = true;
     }
   }
@@ -76,6 +85,7 @@ public class DTRecoveryCommand extends DTTargetCommand {
     try {
       return threwException || target.isFinished();
     } catch (RuntimeException e) {
+      DTLogWriter.logException(e, DTLog.Level.DEBUG);
       threwException = true;
       return true;
     }
@@ -86,6 +96,7 @@ public class DTRecoveryCommand extends DTTargetCommand {
     try {
       return !threwException && target.wasSuccessful();
     } catch (RuntimeException e) {
+      DTLogWriter.logException(e, DTLog.Level.DEBUG);
       threwException = true;
       return false;
     }

--- a/src/main/java/org/victorrobotics/dtlib/controller/DTController.java
+++ b/src/main/java/org/victorrobotics/dtlib/controller/DTController.java
@@ -1,6 +1,7 @@
 package org.victorrobotics.dtlib.controller;
 
 import org.victorrobotics.dtlib.command.DTCommandScheduler;
+import org.victorrobotics.dtlib.log.DTLogWriter;
 
 import edu.wpi.first.hal.DriverStationJNI;
 import edu.wpi.first.math.geometry.Translation2d;
@@ -26,7 +27,7 @@ public class DTController {
       throw new ArrayIndexOutOfBoundsException(port);
     }
     if (INSTANCES[port] != null) {
-      DriverStation.reportWarning("Controller already instantiated at port " + port, isConnected());
+      DTLogWriter.warn("Controller already instantiated at port " + port);
     }
     this.port = port;
     INSTANCES[port] = this;

--- a/src/main/java/org/victorrobotics/dtlib/hardware/kauailabs/DTNavX.java
+++ b/src/main/java/org/victorrobotics/dtlib/hardware/kauailabs/DTNavX.java
@@ -16,11 +16,7 @@ public class DTNavX implements DTInertialMeasurementUnit {
 
   @Override
   public void close() {
-    try {
-      internal.close();
-    } catch (Exception e) {
-      // ignore
-    }
+    internal.close();
   }
 
   @Override

--- a/src/main/java/org/victorrobotics/dtlib/log/DTLog.java
+++ b/src/main/java/org/victorrobotics/dtlib/log/DTLog.java
@@ -5,15 +5,100 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * An annotation that indicates to DTLog that an element's value changes should
+ * be recorded every robot cycle. This annotation can be applied in several
+ * different places, including object members, object getter methods, static
+ * class variables and constants, and static getter methods. However, this
+ * annotation alone does not guarantee discovery by the logger.
+ *
+ * @see <a href=
+ *      "https://github.com/Team1559/DTLib/blob/master/src/main/java/org/victorrobotics/dtlib/log/DTLog.md">DTLog.md</a>
+ */
 @Target({ ElementType.FIELD, ElementType.METHOD })
 @Retention(RetentionPolicy.RUNTIME)
 public @interface DTLog {
-  String value() default "";
+  /**
+   * The name to use in the variable's logging path (and its children). If empty
+   * (default), it will be automatically generated from the accessor's
+   * properties.
+   *
+   * @return the loggable name of this variable
+   */
+  String name() default "";
 
+  /**
+   * The minimum level at which to begin logging this variable. If this level is
+   * more verbose than this variable's parent object, the variable will be
+   * ignored.
+   *
+   * @return
+   */
+  Level level() default Level.INFO;
+
+  /**
+   * The amount of detail to include in generated logs and messages.
+   * <p>
+   * Robots: a global setting. Variables and messages more verbose than this
+   * will be ignored. Defaults to {@link #INFO}.
+   * <p>
+   * Variables: determines whether a variable (and its children, if any) will be
+   * logged. Variables more verbose than the log level of their parent will be
+   * ignored. Defaults to {@link #INFO}.
+   * <p>
+   * Messages: determines whether a text message will be logged to disk, AND
+   * whether it will be printed. Messages more verbose than the robot log level
+   * will be ignored. Defaults to {@link #INFO}.
+   */
   public enum Level {
+    /**
+     * The most verbose level, recording all data tagged as loggable.
+     * <p>
+     * Robots: use only while debugging specific code. Should not be used during
+     * competition, as it can incur a significant performance penalty. Enable
+     * one subsystem at most to prevent clutter.
+     * <p>
+     * Variables: use when obtaining values that may incur a performance penalty
+     * (e.g. cacheless CAN transactions), or values that don't seem useful most
+     * of the time.
+     * <p>
+     * Messages: use for large nonessential messages and traces.
+     */
     DEBUG(0x0008),
+    /**
+     * A level that provides useful information in addition to warnings and
+     * errors. This is the default value for all categories.
+     * <p>
+     * Robots: use during general development. Not reecommended during
+     * competition due to cluttered console output.
+     * <p>
+     * Variables: use for general logging of data points.
+     * <p>
+     * Messages: use for succinct nonessential messages.
+     */
     INFO(0x0009),
+    /**
+     * A level that provides a balance between data and performance/bandwidth.
+     * <p>
+     * Robots: use during testing. Recommended for use during competition.
+     * <p>
+     * Variables: use for variables that should be logged consistently.
+     * <p>
+     * Messages: use for warnings that aren't critical, but should be fixed.
+     * Text will be bolded in yellow.
+     */
     WARN(0x000A),
+    /**
+     * A level that uses as little bandwidth as possible, logging only essential
+     * data and messages.
+     * <p>
+     * Robots: not recommended unless performance becomes an issue.
+     * <p>
+     * Variables: use for essential variables that must always be logged.
+     * <p>
+     * Messages: use for warnings which require immediate attention. Text will
+     * be bolded in red.
+     */
     ERROR(0x000B);
 
     final int typeID;

--- a/src/main/java/org/victorrobotics/dtlib/log/DTLog.md
+++ b/src/main/java/org/victorrobotics/dtlib/log/DTLog.md
@@ -157,7 +157,7 @@ Each log file begins with a 32-byte header containing metadata about the log. Th
     - 1 byte for the major version
     - 1 byte for the minor version
 4. Team Number
-    - 2 bytes for the team number, or `0xFFFF` if unknown
+    - 2 bytes for the team number, or 0 if unknown
 5. Timestamp
     - A 6-byte integer of the current system time since the Unix epoch in milliseconds
 6. Checksum

--- a/src/main/java/org/victorrobotics/dtlib/log/DTLogBuiltinTypes.java
+++ b/src/main/java/org/victorrobotics/dtlib/log/DTLogBuiltinTypes.java
@@ -14,6 +14,7 @@ import edu.wpi.first.math.geometry.Translation3d;
 import edu.wpi.first.math.geometry.Twist2d;
 import edu.wpi.first.math.geometry.Twist3d;
 
+@SuppressWarnings("java:S1602") // "Useless" curly braces around lambdas
 public final class DTLogBuiltinTypes {
   private DTLogBuiltinTypes() {}
 

--- a/src/main/java/org/victorrobotics/dtlib/log/DTLogRootNode.java
+++ b/src/main/java/org/victorrobotics/dtlib/log/DTLogRootNode.java
@@ -1,7 +1,5 @@
 package org.victorrobotics.dtlib.log;
 
-import org.victorrobotics.dtlib.DTRobot;
-
 import java.util.ArrayDeque;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -12,8 +10,8 @@ public class DTLogRootNode extends DTLogTreeNode {
 
   private final DTLogStaticVar[] staticVars;
 
-  public DTLogRootNode(DTRobot robot, DTLog.Level robotLogLevel) {
-    super("", robot.getName(), robot.getClass(), unused -> robot);
+  public DTLogRootNode(Object robot, DTLog.Level robotLogLevel) {
+    super("", robot.toString(), robot.getClass(), unused -> robot);
 
     Map<DTLogStaticVar, DTLog.Level> staticVarList = new LinkedHashMap<>();
     init(new ArrayDeque<>(), new LinkedHashSet<>(), staticVarList, robotLogLevel);

--- a/src/main/java/org/victorrobotics/dtlib/log/DTLogRootNode.java
+++ b/src/main/java/org/victorrobotics/dtlib/log/DTLogRootNode.java
@@ -1,26 +1,34 @@
 package org.victorrobotics.dtlib.log;
 
+import org.victorrobotics.dtlib.DTRobot;
+
 import java.util.ArrayDeque;
-import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
-import java.util.List;
+import java.util.Map;
 
 public class DTLogRootNode extends DTLogTreeNode {
-  private final Object           root;
+  private static final Object NO_PARENT_OBJ = new Object();
+
   private final DTLogStaticVar[] staticVars;
 
-  public DTLogRootNode(Object root, String name) {
-    super("", name, root.getClass(), dummy -> root);
-    this.root = root;
+  public DTLogRootNode(DTRobot robot, DTLog.Level robotLogLevel) {
+    super("", robot.getName(), robot.getClass(), unused -> robot);
 
-    List<DTLogStaticVar> staticVarList = new ArrayList<>();
-    init(new ArrayDeque<>(), new LinkedHashSet<>(), staticVarList);
-    staticVars = staticVarList.toArray(DTLogStaticVar[]::new);
+    Map<DTLogStaticVar, DTLog.Level> staticVarList = new LinkedHashMap<>();
+    init(new ArrayDeque<>(), new LinkedHashSet<>(), staticVarList, robotLogLevel);
+
+    staticVarList.entrySet()
+                 .removeIf(entry -> {
+                   DTLog.Level varLogLevel = entry.getValue();
+                   return varLogLevel.ordinal() < robotLogLevel.ordinal();
+                 });
+    staticVars = staticVarList.keySet()
+                              .toArray(DTLogStaticVar[]::new);
   }
 
   public void log() {
-    // Input is discarded, but cannot be null
-    log(root);
+    log(NO_PARENT_OBJ);
     for (DTLogStaticVar staticVar : staticVars) {
       staticVar.log();
     }

--- a/src/main/java/org/victorrobotics/dtlib/log/DTLogTreeNode.java
+++ b/src/main/java/org/victorrobotics/dtlib/log/DTLogTreeNode.java
@@ -6,10 +6,9 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
-import java.util.ArrayList;
 import java.util.Deque;
-import java.util.Iterator;
-import java.util.List;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.Set;
 import java.util.function.UnaryOperator;
 
@@ -28,16 +27,16 @@ public class DTLogTreeNode {
   }
 
   protected final void init(Deque<Class<?>> stack, Set<Class<?>> clazzes,
-      List<DTLogStaticVar> staticVars) {
+                            Map<DTLogStaticVar, DTLog.Level> staticVars, DTLog.Level logLevel) {
     if (stack.contains(type)) {
       // Prevent infinite recursion
       return;
     }
 
-    List<DTLogTreeNode> childList = new ArrayList<>();
+    Map<DTLogTreeNode, DTLog.Level> childrenMap = new LinkedHashMap<>();
     Class<?> clazz = type;
-    do {
-      if (childList.isEmpty()) {
+    while (clazz != null) {
+      if (childrenMap.isEmpty()) {
         DTLogType logType = DTLogWriter.LOG_TYPES.get(clazz);
         if (logType != null) {
           variable = new DTLogVar(logType, path);
@@ -48,117 +47,108 @@ public class DTLogTreeNode {
       boolean includeStatic = clazzes.add(clazz);
 
       for (Field field : clazz.getDeclaredFields()) {
-        initField(field, childList, staticVars, includeStatic);
+        initField(field, childrenMap, staticVars, includeStatic);
       }
 
       for (Method method : clazz.getDeclaredMethods()) {
-        initMethod(method, childList, staticVars, includeStatic);
+        initMethod(method, childrenMap, staticVars, includeStatic);
       }
 
       clazz = clazz.getSuperclass();
-    } while (clazz != null);
+    }
 
     stack.addFirst(type);
-    initChildren(stack, clazzes, staticVars, childList);
+    childrenMap.entrySet()
+               .removeIf(entry -> {
+                 DTLog.Level childLogLevel = entry.getValue();
+                 if (childLogLevel.ordinal() < logLevel.ordinal()) return true;
+
+                 DTLogTreeNode child = entry.getKey();
+                 child.init(stack, clazzes, staticVars, childLogLevel);
+                 return child.variable == null && child.children == null;
+               });
     stack.removeFirst();
 
-    children = childList.isEmpty() ? null : childList.toArray(DTLogTreeNode[]::new);
+    this.children = childrenMap.isEmpty() ? null : childrenMap.keySet()
+                                                              .toArray(DTLogTreeNode[]::new);
   }
 
-  private void initField(Field field, List<DTLogTreeNode> childList,
-      List<DTLogStaticVar> staticVars, boolean includeStatic) {
+  private void initField(Field field, Map<DTLogTreeNode, DTLog.Level> childList,
+                         Map<DTLogStaticVar, DTLog.Level> staticVars, boolean includeStatic) {
     DTLog annotation = field.getAnnotation(DTLog.class);
-    if (annotation == null) {
-      return;
-    }
+    if (annotation == null) return;
 
     boolean isStatic = Modifier.isStatic(field.getModifiers());
-    if (isStatic && !includeStatic) {
-      return;
-    }
+    if (isStatic && !includeStatic) return;
 
-    if (!field.trySetAccessible()) {
-      return;
-    }
+    if (!field.trySetAccessible()) return;
 
-    String name = annotation.value();
+    String name = annotation.name();
     if (!isValidName(name)) {
       name = field.getName();
     }
 
     if (isStatic) {
       DTLogType logType = DTLogWriter.LOG_TYPES.get(field.getType());
-      if (logType == null) {
-        return;
-      }
+      if (logType == null) return;
 
-      staticVars.add(new DTLogStaticVar(logType, field.getDeclaringClass(), name, () -> {
+      staticVars.put(new DTLogStaticVar(logType, field.getDeclaringClass(), name, () -> {
         try {
           return field.get(null);
         } catch (IllegalAccessException | IllegalArgumentException e) {
           return null;
         }
-      }));
+      }), annotation.level());
       return;
     }
 
-    childList.add(new DTLogTreeNode(path, name, field.getType(), parent -> {
+    childList.put(new DTLogTreeNode(path, name, field.getType(), parent -> {
       try {
         return field.get(parent);
       } catch (IllegalAccessException | IllegalArgumentException e) {
         return null;
       }
-    }));
+    }), annotation.level());
   }
 
-  private void initMethod(Method method, List<DTLogTreeNode> childList,
-      List<DTLogStaticVar> staticVars, boolean includeStatic) {
+  private void initMethod(Method method, Map<DTLogTreeNode, DTLog.Level> childList,
+                          Map<DTLogStaticVar, DTLog.Level> staticVars, boolean includeStatic) {
     DTLog annotation = method.getAnnotation(DTLog.class);
-    if (annotation == null) {
-      return;
-    }
+    if (annotation == null) return;
 
-    if (method.getParameterCount() != 0 || method.getReturnType() == void.class) {
-      return;
-    }
+    if (method.getParameterCount() != 0 || method.getReturnType() == void.class) return;
 
     boolean isStatic = Modifier.isStatic(method.getModifiers());
-    if (isStatic && !includeStatic) {
-      return;
-    }
+    if (isStatic && !includeStatic) return;
 
-    if (!method.trySetAccessible()) {
-      return;
-    }
+    if (!method.trySetAccessible()) return;
 
-    String name = annotation.value();
+    String name = annotation.name();
     if (!isValidName(name)) {
       name = method.getName() + "()";
     }
 
     if (isStatic) {
       DTLogType logType = DTLogWriter.LOG_TYPES.get(method.getReturnType());
-      if (logType == null) {
-        return;
-      }
+      if (logType == null) return;
 
-      staticVars.add(new DTLogStaticVar(logType, method.getDeclaringClass(), name, () -> {
+      staticVars.put(new DTLogStaticVar(logType, method.getDeclaringClass(), name, () -> {
         try {
           return method.invoke(null, (Object[]) null);
         } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
           return null;
         }
-      }));
+      }), annotation.level());
       return;
     }
 
-    childList.add(new DTLogTreeNode(path, name, method.getReturnType(), parent -> {
+    childList.put(new DTLogTreeNode(path, name, method.getReturnType(), parent -> {
       try {
         return method.invoke(parent, (Object[]) null);
       } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
         return null;
       }
-    }));
+    }), annotation.level());
   }
 
   protected void log(Object parent) {
@@ -202,18 +192,6 @@ public class DTLogTreeNode {
              .append(children[i]);
     }
     return builder.toString();
-  }
-
-  private static void initChildren(Deque<Class<?>> stack, Set<Class<?>> clazzes,
-      List<DTLogStaticVar> staticVars, List<DTLogTreeNode> childList) {
-    Iterator<DTLogTreeNode> itr = childList.iterator();
-    while (itr.hasNext()) {
-      DTLogTreeNode child = itr.next();
-      child.init(stack, clazzes, staticVars);
-      if (child.variable == null && child.children == null) {
-        itr.remove();
-      }
-    }
   }
 
   private static boolean isValidName(String name) {

--- a/src/main/java/org/victorrobotics/dtlib/log/DTLogTreeNode.java
+++ b/src/main/java/org/victorrobotics/dtlib/log/DTLogTreeNode.java
@@ -96,6 +96,7 @@ public class DTLogTreeNode {
         try {
           return field.get(null);
         } catch (IllegalAccessException | IllegalArgumentException e) {
+          DTLogWriter.logException(e, DTLog.Level.ERROR);
           return null;
         }
       }), annotation.level());
@@ -106,6 +107,7 @@ public class DTLogTreeNode {
       try {
         return field.get(parent);
       } catch (IllegalAccessException | IllegalArgumentException e) {
+        DTLogWriter.logException(e, DTLog.Level.ERROR);
         return null;
       }
     }), annotation.level());
@@ -136,6 +138,7 @@ public class DTLogTreeNode {
         try {
           return method.invoke(null, (Object[]) null);
         } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
+          DTLogWriter.logException(e, DTLog.Level.ERROR);
           return null;
         }
       }), annotation.level());
@@ -146,6 +149,7 @@ public class DTLogTreeNode {
       try {
         return method.invoke(parent, (Object[]) null);
       } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
+        DTLogWriter.logException(e, DTLog.Level.ERROR);
         return null;
       }
     }), annotation.level());

--- a/src/main/java/org/victorrobotics/dtlib/log/DTLogTreeNode.java
+++ b/src/main/java/org/victorrobotics/dtlib/log/DTLogTreeNode.java
@@ -1,5 +1,7 @@
 package org.victorrobotics.dtlib.log;
 
+import static org.victorrobotics.dtlib.log.DTLogWriter.LOG_PATH_SEPARATOR;
+
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -20,7 +22,7 @@ public class DTLogTreeNode {
   private DTLogVar        variable;
 
   public DTLogTreeNode(String path, String name, Class<?> type, UnaryOperator<Object> getter) {
-    this.path = path + "/" + name;
+    this.path = path + LOG_PATH_SEPARATOR + name;
     this.type = type;
     this.getter = getter;
   }
@@ -176,7 +178,6 @@ public class DTLogTreeNode {
     }
   }
 
-  @SuppressWarnings("unchecked")
   private void logNull() {
     if (variable != null) {
       variable.logValue(null);

--- a/src/main/java/org/victorrobotics/dtlib/log/DTLogVar.java
+++ b/src/main/java/org/victorrobotics/dtlib/log/DTLogVar.java
@@ -15,10 +15,7 @@ public class DTLogVar {
 
   @SuppressWarnings("unchecked")
   void logValue(Object value) {
-    if (type.equals.test(prevValue, value)) {
-      return;
-    }
-    prevValue = value;
+    if (type.equals.test(prevValue, value)) return;
 
     if (handle < 0) {
       handle = DTLogWriter.getInstance()
@@ -34,6 +31,7 @@ public class DTLogVar {
                  .writeShort(handle);
       type.writer.accept(value);
     }
+    prevValue = value;
   }
 
   @Override

--- a/src/main/java/org/victorrobotics/dtlib/log/DTLogWriter.java
+++ b/src/main/java/org/victorrobotics/dtlib/log/DTLogWriter.java
@@ -23,6 +23,7 @@ import java.util.BitSet;
 import java.util.HashMap;
 import java.util.Map;
 
+import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.RobotController;
 import edu.wpi.first.wpilibj.util.WPILibVersion;
 
@@ -373,6 +374,14 @@ public final class DTLogWriter implements Closeable, Flushable {
   private boolean logMessage(String msg, DTLog.Level logLevel) {
     if (logLevel.ordinal() < level.ordinal()) {
       return false;
+    }
+
+    if (logLevel == DTLog.Level.ERROR) {
+      DriverStation.reportError(msg, false);
+    } else if (logLevel == DTLog.Level.WARN) {
+      DriverStation.reportWarning(msg, false);
+    } else {
+      System.out.println(msg);
     }
 
     writeShort(logLevel.typeID);

--- a/src/main/java/org/victorrobotics/dtlib/log/DTLogWriter.java
+++ b/src/main/java/org/victorrobotics/dtlib/log/DTLogWriter.java
@@ -1,38 +1,34 @@
 package org.victorrobotics.dtlib.log;
 
-import org.victorrobotics.dtlib.DTLibInfo;
-import org.victorrobotics.dtlib.exception.DTIllegalArgumentException;
-
 import static java.nio.file.StandardOpenOption.CREATE;
 import static java.nio.file.StandardOpenOption.TRUNCATE_EXISTING;
 import static java.nio.file.StandardOpenOption.WRITE;
+
+import org.victorrobotics.dtlib.DTLibInfo;
+import org.victorrobotics.dtlib.DTRobot;
+import org.victorrobotics.dtlib.exception.DTIllegalArgumentException;
 
 import java.io.Closeable;
 import java.io.File;
 import java.io.Flushable;
 import java.io.IOException;
-import java.net.InetAddress;
-import java.net.NetworkInterface;
-import java.net.SocketException;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.charset.StandardCharsets;
 import java.time.Clock;
 import java.time.Instant;
-import java.time.LocalDate;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.BitSet;
-import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Map;
 
-import edu.wpi.first.wpilibj.DriverStation;
-import edu.wpi.first.wpilibj.RobotBase;
 import edu.wpi.first.wpilibj.RobotController;
 import edu.wpi.first.wpilibj.util.WPILibVersion;
 
 public final class DTLogWriter implements Closeable, Flushable {
+  public static final String LOG_PATH_SEPARATOR = "/";
+
   private static final DateTimeFormatter TIME_FORMATTER = // UTC
       DateTimeFormatter.ofPattern("uuuu-MM-dd_HH-mm-ss")
                        .withZone(ZoneId.of("Z"));
@@ -40,16 +36,16 @@ public final class DTLogWriter implements Closeable, Flushable {
   private static final String LOG_DIRECTORY      = "/dev/sda/logs";
   private static final byte[] HEADER_MAGIC_BYTES = "DTLib Logger".getBytes(StandardCharsets.UTF_8);
 
-  // @format:off
+  @SuppressWarnings("java:S1764") // XOR identical elements
   private static final int HEADER_MAGIC_XOR =
+  // @format:off
       (('D' ^ 'b' ^ 'g') << 24) |
       (('T' ^ ' ' ^ 'g') << 16) |
       (('L' ^ 'L' ^ 'e') <<  8) |
       (('i' ^ 'o' ^ 'r') <<  0);
   // @format:on
 
-  private static final int BUFFER_SIZE         = 65536;
-  private static final int UNKNOWN_TEAM_NUMBER = 0xFFFF;
+  private static final int BUFFER_SIZE_BYTES = 64 * 1024;
 
   private static DTLogWriter INSTANCE;
 
@@ -70,24 +66,25 @@ public final class DTLogWriter implements Closeable, Flushable {
   private DTLogWriter() throws IOException {
     Instant now = Clock.systemUTC()
                        .instant();
-    lastTimestamp = RobotController.getFPGATime() / 1_000;
+    lastTimestamp = DTRobot.currentTimeMicros() / 1000;
     long startTimeMillis = now.toEpochMilli();
     String name = "LOG_" + TIME_FORMATTER.format(now) + ".dtlog";
 
     file = new File(LOG_DIRECTORY, name);
     channel = FileChannel.open(file.toPath(), WRITE, CREATE, TRUNCATE_EXISTING);
-    buffer = ByteBuffer.allocateDirect(BUFFER_SIZE);
+    buffer = ByteBuffer.allocateDirect(BUFFER_SIZE_BYTES);
     bitSet = new BitSet();
 
     writeBytes(HEADER_MAGIC_BYTES);
     int checksum = HEADER_MAGIC_XOR;
 
-    int dtlibVersion = (DTLibInfo.Version.YEAR << 16) | (DTLibInfo.Version.MAJOR << 8)
-        | DTLibInfo.Version.MINOR;
+    int dtlibVersion =
+        (DTLibInfo.Version.YEAR << 16) | (DTLibInfo.Version.MAJOR << 8) | DTLibInfo.Version.MINOR;
     writeInt(dtlibVersion);
     checksum ^= dtlibVersion;
 
-    String[] wpilibVersions = WPILibVersion.Version.split("\\.");
+    String[] wpilibVersions = WPILibVersion.Version.substring(0, WPILibVersion.Version.indexOf('-'))
+                                                   .split("\\.");
     int wpilibYear = Integer.parseInt(wpilibVersions[0]);
     int wpilibMajor = Integer.parseInt(wpilibVersions[1]);
     int wpilibMinor = Integer.parseInt(wpilibVersions[2]);
@@ -95,12 +92,12 @@ public final class DTLogWriter implements Closeable, Flushable {
     writeInt(wpilibVersion);
     checksum ^= wpilibVersion;
 
-    int team = getTeamNumber();
-    writeLong(((long) team << 48) | startTimeMillis);
+    long team = DTRobot.getTeamNumber();
+    writeLong((team << 48) | startTimeMillis);
     checksum ^= team << 16;
     checksum ^= (int) ((startTimeMillis >> 32) | startTimeMillis);
-
     writeInt(checksum);
+
     flush();
   }
 
@@ -146,6 +143,7 @@ public final class DTLogWriter implements Closeable, Flushable {
     return this;
   }
 
+  @SuppressWarnings("java:S2301") // boolean "flag" as method parameter
   public DTLogWriter writeBoolean(boolean b) {
     checkBufferRemaining(1);
     buffer.put((byte) (b ? 1 : 0));
@@ -315,13 +313,17 @@ public final class DTLogWriter implements Closeable, Flushable {
   }
 
   public boolean tryFlush() {
+    int bufferPos = buffer.position();
+    buffer.flip();
     try {
-      flush();
-      return true;
+      channel.write(buffer);
     } catch (IOException e) {
-      // TODO: don't ignore this
+      buffer.position(bufferPos);
+      buffer.limit(buffer.capacity());
       return false;
     }
+    buffer.compact();
+    return true;
   }
 
   private boolean checkBufferRemaining(int newDataLength) {
@@ -350,14 +352,12 @@ public final class DTLogWriter implements Closeable, Flushable {
   }
 
   public boolean logNewTimestamp() {
-    long newTime = RobotController.getFPGATime() / 1000;
-    long diff = newTime - lastTimestamp;
-    if (diff <= 0) {
-      // Same time, no change
-      return false;
-    }
-    lastTimestamp = newTime;
+    long newTime = DTRobot.currentTimeMicros() / 1000;
 
+    long diff = newTime - lastTimestamp;
+    if (diff <= 0) return false;
+
+    lastTimestamp = newTime;
     if (diff <= 0xFFFF) {
       // write increment, maximum of 65.535 seconds
       INSTANCE.writeInt((0x01 << 16) | (int) diff);
@@ -375,70 +375,20 @@ public final class DTLogWriter implements Closeable, Flushable {
 
   public static void init() {
     while (true) {
+      if (!RobotController.isSystemTimeValid()) {
+        try {
+          INSTANCE = new DTLogWriter();
+          return;
+        } catch (IOException e) {}
+      }
+
       try {
         Thread.sleep(100);
-      } catch (InterruptedException e) {
-        // ignore
-      }
-
-      if (!isTimeSynchronized()) {
-        continue;
-      }
-
-      try {
-        INSTANCE = new DTLogWriter();
-        return;
-      } catch (IOException e) {
-        // ignore
-      }
+      } catch (InterruptedException e) {}
     }
-  }
-
-  private static boolean isTimeSynchronized() {
-    return DriverStation.isDSAttached() && LocalDate.now(Clock.systemUTC())
-                                                    .getYear() >= 2000;
   }
 
   public static DTLogWriter getInstance() {
     return INSTANCE;
-  }
-
-  private static int getTeamNumber() {
-    if (RobotBase.isSimulation()) {
-      return UNKNOWN_TEAM_NUMBER;
-    }
-
-    Enumeration<NetworkInterface> interfaces;
-    try {
-      interfaces = NetworkInterface.getNetworkInterfaces();
-    } catch (SocketException e) {
-      return UNKNOWN_TEAM_NUMBER;
-    }
-
-    // Use IP address 10.??.??.2 to obtain team number
-    while (interfaces.hasMoreElements()) {
-      NetworkInterface i = interfaces.nextElement();
-      Enumeration<InetAddress> addresses = i.getInetAddresses();
-      while (addresses.hasMoreElements()) {
-        String[] split = addresses.nextElement()
-                                  .getHostAddress()
-                                  .split("\\.");
-        if (!"10".equals(split[0]) || !"41".equals(split[3])) {
-          continue;
-        }
-
-        try {
-          int hundreds = Integer.parseInt(split[1]);
-          int ones = Integer.parseInt(split[2]);
-          if (hundreds < 100 && ones < 100) {
-            return hundreds * 100 + ones;
-          }
-        } catch (NumberFormatException e) {
-          // ignore
-        }
-      }
-    }
-
-    return UNKNOWN_TEAM_NUMBER;
   }
 }

--- a/src/main/java/org/victorrobotics/dtlib/log/DTLogWriter.java
+++ b/src/main/java/org/victorrobotics/dtlib/log/DTLogWriter.java
@@ -445,7 +445,7 @@ public final class DTLogWriter implements Closeable, Flushable {
 
   public static void init(DTLog.Level logLevel) {
     while (true) {
-      if (!RobotController.isSystemTimeValid()) {
+      if (RobotController.isSystemTimeValid()) {
         try {
           INSTANCE = new DTLogWriter(logLevel);
           return;

--- a/src/main/java/org/victorrobotics/dtlib/log/DTWatchdog.java
+++ b/src/main/java/org/victorrobotics/dtlib/log/DTWatchdog.java
@@ -6,8 +6,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
 
-import edu.wpi.first.wpilibj.DriverStation;
-
 public final class DTWatchdog {
   private static class Epoch {
     private final String label;
@@ -54,20 +52,13 @@ public final class DTWatchdog {
     epochStartTime = time;
   }
 
-  public static void printEpochs() {
-    printEpochs(str -> DriverStation.reportWarning(str, false));
-  }
-
-  public static void printEpochs(Consumer<String> action) {
+  public static void printEpochs(Consumer<String> header, Consumer<String> details) {
     long time = DTRobot.currentTimeMicros();
     if (time < minPrintTime) return;
     minPrintTime = time + MIN_PRINT_DELAY;
 
-    StringBuilder builder =
-        new StringBuilder("Loop Overrun: ").append((time - loopStartTime) * 1e-6)
-                                           .append(" seconds")
-                                           .append(System.lineSeparator());
-
+    header.accept("Loop Overrun: " + (time - loopStartTime) * 1e-6 + " seconds");
+    
     int labelLength = 0;
     for (Epoch epoch : EPOCHS) {
       int len = epoch.label.length();
@@ -75,11 +66,13 @@ public final class DTWatchdog {
         labelLength = len;
       }
     }
+
     String format = "%-" + labelLength + "s - %.6f%n";
+    StringBuilder builder = new StringBuilder();
     EPOCHS.forEach(epoch -> builder.append(String.format(format, epoch.label,
                                                          epoch.duration * 1e-6)));
 
-    action.accept(builder.toString());
+    details.accept(builder.toString());
   }
 
   public static void startEpoch() {


### PR DESCRIPTION
- Add version suffix in DTLibInfo
- Remove duplicate mode logging
- Use tryFlush() instead of flush()
- Add constant LOG_PATH_SEPARATOR
- Use RobotController.getTeamNumber() instead of custom implementation
- Change unknown team number to 0
- General cleanup, suppress useless warnings